### PR TITLE
Allow Android Studio to show desktop notifications

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -10,6 +10,7 @@
 		"--device=all",
 		"--filesystem=home",
 		"--allow=multiarch",
+		"--talk-name=org.freedesktop.Notifications",
 		"--env=JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
 	],
 	"cleanup": [


### PR DESCRIPTION
The application uses `libnotify`, and this patch lets it talk to `org.freedesktop.Notifications` on the session bus, which is the D-Bus interface used by `libnotify`.

With this applied, notifications sent by Android Studio after certain long-running events (e.g. building a project) work as expected:

![android-studio-libnotify](https://cloud.githubusercontent.com/assets/723451/20675248/4f07e83e-b594-11e6-910c-3720e19327a5.png)
