### PR TITLE
Install additional icon sizes for Android Studio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,13 @@ install:
 	cp com.google.AndroidStudio.appdata.xml /app/share/appdata
 	mkdir -p /app/share/icons/hicolor/128x128/apps/
 	ln /app/bin/studio.png /app/share/icons/hicolor/128x128/apps/com.google.AndroidStudio.png
+	install -Dm644 ../adt/idea/adt-branding/src/artwork/icon_AS_small.png \
+		/app/share/icons/hicolor/16x16/apps/com.google.AndroidStudio.png
+	install -Dm644 ../adt/idea/adt-branding/src/artwork/icon_AS_small@2x.png \
+		/app/share/icons/hicolor/16x16@2x/apps/com.google.AndroidStudio.png
+	install -Dm644 ../adt/idea/adt-branding/src/artwork/icon_AS.png \
+		/app/share/icons/hicolor/32x32/apps/com.google.AndroidStudio.png
+	install -Dm644 ../adt/idea/adt-branding/src/artwork/androidstudio.svg \
+		/app/share/icons/hicolor/scalable/apps/com.google.AndroidStudio.svg
 
 .PHONY: install


### PR DESCRIPTION
These are included in the package ADT branding for IDEA, including a nice SVG version which will be picked whenever a size different from the pre-rendered PNGs is needed.

With this applied, `flatpak build-finish` picks the additional icons just fine, like in the following `flatpak-builder` run:

```
...
Finishing app
Exporting share/applications/com.google.AndroidStudio.desktop
Exporting share/icons/hicolor/128x128/apps/com.google.AndroidStudio.png
Exporting share/icons/hicolor/16x16/apps/com.google.AndroidStudio.png
Exporting share/icons/hicolor/16x16@2x/apps/com.google.AndroidStudio.png
Exporting share/icons/hicolor/32x32/apps/com.google.AndroidStudio.png
Exporting share/icons/hicolor/scalable/apps/com.google.AndroidStudio.svg
Please review the exported files and the metadata
...
```

https://phabricator.endlessm.com/T14386