### PR TITLE
Preconfigure the path to the JDK used for building Android projects

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -11,6 +11,7 @@
 		"--filesystem=home",
 		"--allow=multiarch",
 		"--talk-name=org.freedesktop.Notifications",
+		"--env=STUDIO_JDK=/usr/lib/jvm/java-8-openjdk-amd64",
 		"--env=JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
 	],
 	"cleanup": [


### PR DESCRIPTION
Without this, Android Studio would complain that there is no JDK available for building when opening a project or starting a new one.

https://phabricator.endlessm.com/T14386