### PR TITLE
Disable the automatic update checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,8 @@ install:
 		/app/share/icons/hicolor/32x32/apps/com.google.AndroidStudio.png
 	install -Dm644 ../adt/idea/adt-branding/src/artwork/androidstudio.svg \
 		/app/share/icons/hicolor/scalable/apps/com.google.AndroidStudio.svg
+	echo '-Dide.no.platform.update=true' >> /app/bin/studio64.vmoptions
+	echo '-Dide.no.platform.update=true' >> /app/bin/studio.vmoptions
+
 
 .PHONY: install

--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -25,7 +25,7 @@
 		"changelog.txt",
 		"ChangeLog",
 		"*.bat",
-		"/*.txt",
+		"/Install-Linux-tar.txt",
 		"/lib/ant/KEYS",
 		"/lib/ant/docs.zip",
 		"/lib/libpty/macosx",


### PR DESCRIPTION
The contents of the Flatpak are immutable, so the updater won't be able to replace the files. This only disables the automatic update checking, and therefore nag screen asking the user to update. Also, avoid removing the `build.txt` file, which contains the build number, so Android Studio will report being version `2.2.2.<buildnumber>` instead of just `2.2.2`.

https://phabricator.endlessm.com/T14386