### PR TITLE
Add .desktop suffix to identifier in AppData XML file

### DIFF
--- a/com.google.AndroidStudio.appdata.xml
+++ b/com.google.AndroidStudio.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-	<id>com.google.AndroidStudio</id>
+	<id>com.google.AndroidStudio.desktop</id>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>Apache-2.0, BSD-2-Clause</project_license>
 	<name>Android Studio</name>


### PR DESCRIPTION
As per the spec, the value contained by the `<id>` tag must have the `.desktop` suffix.

https://phabricator.endlessm.com/T14386