### PR TITLE
set the JDK path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ all:
 install:
 	tar --strip-components=1 -xzf '$(OUTDIR)/artifacts/android-studio-$(VERSION)-no-jdk.tar.gz' -C /app
 	mkdir -p /app/share/applications /app/share/appdata
+	mkdir -p /app/AndroidStudioConfig
 	cp com.google.AndroidStudio.desktop /app/share/applications/
 	cp com.google.AndroidStudio.appdata.xml /app/share/appdata
+	cp jdk.table.xml /app/AndroidStudioConfig/jdk.table.xml
+	cp android.sh /app/bin/android.sh
 	mkdir -p /app/share/icons/hicolor/128x128/apps/
 	ln /app/bin/studio.png /app/share/icons/hicolor/128x128/apps/com.google.AndroidStudio.png
 	install -Dm644 ../adt/idea/adt-branding/src/artwork/icon_AS_small.png \

--- a/android.sh
+++ b/android.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+#
+# Replace jdk.table xml file
+# For Android Studio to detect the correct JDK path
+# we need to preset the path in the jdk.table.xml
+#
+
+OPTIONS_DIR="$HOME/.AndroidStudio2.2/config/options"
+
+if [[ ! -f ${OPTIONS_DIR}/jdk.table.xml ]]; then
+  mkdir -p ${OPTIONS_DIR}
+  cp /app/AndroidStudioConfig/jdk.table.xml ${OPTIONS_DIR}/jdk.table.xml
+fi
+
+exec /app/bin/studio.sh $@

--- a/android.sh
+++ b/android.sh
@@ -8,9 +8,9 @@ set -eu
 
 OPTIONS_DIR="$HOME/.AndroidStudio2.2/config/options"
 
-if [[ ! -f ${OPTIONS_DIR}/jdk.table.xml ]]; then
-  mkdir -p ${OPTIONS_DIR}
-  cp /app/AndroidStudioConfig/jdk.table.xml ${OPTIONS_DIR}/jdk.table.xml
+if [[ ! -f "${OPTIONS_DIR}/jdk.table.xml" ]]; then
+  mkdir -p "${OPTIONS_DIR}"
+  cp /app/AndroidStudioConfig/jdk.table.xml "${OPTIONS_DIR}/jdk.table.xml"
 fi
 
-exec /app/bin/studio.sh $@
+exec /app/bin/studio.sh "$@"

--- a/com.google.AndroidStudio.json.in
+++ b/com.google.AndroidStudio.json.in
@@ -3,7 +3,7 @@
 	"runtime": "com.endlessm.Sdk",
 	"runtime-version": "@BRANCH@",
 	"sdk": "com.endlessm.Sdk",
-	"command": "studio.sh",
+	"command": "android.sh",
 	"finish-args": [
 		"--socket=x11",
 		"--share=ipc",
@@ -249,6 +249,16 @@
 				{
 					"type": "file",
 					"path": "com.google.AndroidStudio.appdata.xml",
+					"dest": "tools/idea"
+				},
+				{
+					"type": "file",
+					"path": "jdk.table.xml",
+					"dest": "tools/idea"
+				},
+				{
+					"type": "file",
+					"path": "android.sh",
 					"dest": "tools/idea"
 				},
 				{

--- a/jdk.table.xml
+++ b/jdk.table.xml
@@ -1,0 +1,99 @@
+<application>
+  <component name="ProjectJdkTable">
+    <jdk version="2">
+      <name value="Android API 24 Platform" />
+      <type value="Android SDK" />
+      <homePath value="$USER_HOME$/Android/Sdk" />
+      <roots>
+        <annotationsPath>
+          <root type="composite">
+            <root type="simple" url="jar://$APPLICATION_HOME_DIR$/plugins/android/lib/androidAnnotations.jar!/" />
+          </root>
+        </annotationsPath>
+        <classPath>
+          <root type="composite">
+            <root type="simple" url="jar://$USER_HOME$/Android/Sdk/platforms/android-24/android.jar!/" />
+            <root type="simple" url="file://$USER_HOME$/Android/Sdk/platforms/android-24/data/res" />
+          </root>
+        </classPath>
+        <javadocPath>
+          <root type="composite">
+            <root type="simple" url="http://developer.android.com/reference/" />
+          </root>
+        </javadocPath>
+        <sourcePath>
+          <root type="composite" />
+        </sourcePath>
+      </roots>
+      <additional jdk="1.8" sdk="android-24" />
+    </jdk>
+    <jdk version="2">
+      <name value="Android API 25 Platform" />
+      <type value="Android SDK" />
+      <homePath value="$USER_HOME$/Android/Sdk" />
+      <roots>
+        <annotationsPath>
+          <root type="composite">
+            <root type="simple" url="jar://$APPLICATION_HOME_DIR$/plugins/android/lib/androidAnnotations.jar!/" />
+          </root>
+        </annotationsPath>
+        <classPath>
+          <root type="composite">
+            <root type="simple" url="jar://$USER_HOME$/Android/Sdk/platforms/android-25/android.jar!/" />
+            <root type="simple" url="file://$USER_HOME$/Android/Sdk/platforms/android-25/data/res" />
+          </root>
+        </classPath>
+        <javadocPath>
+          <root type="composite" />
+        </javadocPath>
+        <sourcePath>
+          <root type="composite">
+            <root type="simple" url="file://$USER_HOME$/Android/Sdk/sources/android-25" />
+          </root>
+        </sourcePath>
+      </roots>
+      <additional jdk="1.8" sdk="android-25" />
+    </jdk>
+    <jdk version="2">
+      <name value="1.8" />
+      <type value="JavaSDK" />
+      <version value="java version &quot;1.8.0_102&quot;" />
+      <homePath value="/usr/lib/jvm/java-8-openjdk-amd64" />
+      <roots>
+        <annotationsPath>
+          <root type="composite">
+            <root type="simple" url="jar://$APPLICATION_HOME_DIR$/lib/jdkAnnotations.jar!/" />
+          </root>
+        </annotationsPath>
+        <classPath>
+          <root type="composite">
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/cldrdata.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/dnsns.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/icedtea-sound.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/jaccess.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/java-atk-wrapper.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/localedata.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunec.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunjce_provider.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/sunpkcs11.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/zipfs.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jce.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/resources.jar!/" />
+            <root type="simple" url="jar:///usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar!/" />
+          </root>
+        </classPath>
+        <javadocPath>
+          <root type="composite" />
+        </javadocPath>
+        <sourcePath>
+          <root type="composite" />
+        </sourcePath>
+      </roots>
+      <additional />
+    </jdk>
+  </component>
+</application>


### PR DESCRIPTION
As agreed, we want the user to be able to use Android Studio and not set the path manually. This at startup reads from the `jdk.table.xml` file the JDK home path, which is set to `/usr/lib/jvm/java-8-openjdk-amd64`.

Due to the possibility of breaking the app functionality, when doing a patch for Android Studio itself, I decided to go with just placing the config file at first run.

cc @aperezdc 

https://phabricator.endlessm.com/T14386