### PR TITLE
adjust desktop file exec to android.sh

### DIFF
--- a/com.google.AndroidStudio.desktop
+++ b/com.google.AndroidStudio.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Android Studio
-Exec=studio.sh
+Exec=android.sh
 Icon=com.google.AndroidStudio
 Comment=Development environment for the Android platform
 Terminal=false


### PR DESCRIPTION
The first thing executed should be the android.sh not studio.sh, as we
rely on that to place the jdk.table.xml file in our config.

https://phabricator.endlessm.com/T14386

cc @aperezdc @erikos 